### PR TITLE
Make system config settings global for Login As Customer

### DIFF
--- a/app/code/Magento/LoginAsCustomer/etc/adminhtml/system.xml
+++ b/app/code/Magento/LoginAsCustomer/etc/adminhtml/system.xml
@@ -7,28 +7,28 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="mfloginascustomer" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="mfloginascustomer" translate="label" type="text" sortOrder="1" showInDefault="1" >
             <class>separator-top</class>
             <label>Login As Customer</label>
             <tab>customer</tab>
             <resource>Magento_LoginAsCustomer::config_section</resource>
-            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" canRestore="1">
                 <label>Login As Customer Information</label>
-                <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" canRestore="1">
                     <label>Enable Extension</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="disable_page_cache" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="disable_page_cache" translate="label" type="select" sortOrder="20" showInDefault="1" canRestore="1">
                     <label>Disable Page Cache For Admin User</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[If set to "Yes", when login as customer Page Cache will be disabled.]]></comment>
                 </field>
-                <field id="keep_guest_cart" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="keep_guest_cart" translate="label" type="select" sortOrder="30" showInDefault="1" canRestore="1">
                     <label>Keep Guest Shopping Cart Items</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[If set to "Yes", after login, guest shopping cart will be merged into customer shopping cart.]]></comment>
                 </field>
-                <field id="store_view_login" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="store_view_login" translate="label" type="select" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>Store View To Login In</label>
                     <source_model>Magento\LoginAsCustomer\Model\Config\Source\StoreViewLogin</source_model>
                     <comment><![CDATA[


### PR DESCRIPTION
### Description (*)
Make all Login As Customer extension Store Configuration options global.


### Fixed Issues (if relevant)
https://github.com/magento/magento2-login-as-customer/issues/16:All System Configuration settings should be on Global level

### Manual testing scenarios (*)
The test case can be found here 
https://github.com/magento/magento2-login-as-customer/issues/16

### Contribution checklist (*)
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
