### PR TITLE
34 remove option to merge guest cart

### DIFF
--- a/app/code/Magento/LoginAsCustomer/CustomerData/LoginAsCustomer.php
+++ b/app/code/Magento/LoginAsCustomer/CustomerData/LoginAsCustomer.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\LoginAsCustomer\CustomerData;
+
+use Magento\Customer\CustomerData\SectionSourceInterface;
+use Magento\Customer\Model\Session;
+
+/**
+ * Customer data for the logged_as_customer section
+ */
+class LoginAsCustomer implements SectionSourceInterface
+{
+    /**
+     * @var Session
+     */
+    private $customerSession;
+
+    /**
+     * LoginAsCustomer constructor.
+     * @param Session $customerSession
+     */
+    public function __construct(
+        Session $customerSession
+    ) {
+        $this->customerSession = $customerSession;
+    }
+
+    /**
+     * Retrieve private customer data for the logged_as_customer section
+     * @return array
+     */
+    public function getSectionData():array
+    {
+        if (!$this->customerSession->getCustomerId()) {
+            return [];
+        }
+
+        return [
+            'admin_user_id' => $this->customerSession->getLoggedAsCustomerAdmindId(),
+        ];
+    }
+}

--- a/app/code/Magento/LoginAsCustomer/Model/Login.php
+++ b/app/code/Magento/LoginAsCustomer/Model/Login.php
@@ -17,8 +17,6 @@ class Login extends \Magento\Framework\Model\AbstractModel
      */
     const TIME_FRAME = 60;
 
-    const XML_PATH_KEEP_GUEST_CART = 'mfloginascustomer/general/keep_guest_cart';
-
     /**
      * Prefix of model events names
      *
@@ -189,19 +187,10 @@ class Login extends \Magento\Framework\Model\AbstractModel
             /* Logout if logged in */
             $this->_customerSession->logout();
         } else {
-
             $quote = $this->cart->getQuote();
-
-            $keepItems = $this->scopeConfig->getValue(
-                self::XML_PATH_KEEP_GUEST_CART,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-            );
-
-            if (!$keepItems) {
-                /* Remove items from guest cart */
-                foreach ($quote->getAllVisibleItems() as $item) {
-                    $this->cart->removeItem($item->getId());
-                }
+            /* Remove items from guest cart */
+            foreach ($quote->getAllVisibleItems() as $item) {
+                $this->cart->removeItem($item->getId());
             }
             $this->cart->save();
         }

--- a/app/code/Magento/LoginAsCustomer/ViewModel/Configuration.php
+++ b/app/code/Magento/LoginAsCustomer/ViewModel/Configuration.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\LoginAsCustomer\ViewModel;
+
+/**
+ * View model to get extension configuration in the template
+ */
+class Configuration implements \Magento\Framework\View\Element\Block\ArgumentInterface
+{
+
+    /**
+     * @var \Magento\LoginAsCustomer\Model\Config
+     */
+    private $config;
+
+    /**
+     * Configuration constructor.
+     * @param \Magento\LoginAsCustomer\Model\Config $config
+     */
+    public function __construct(
+        \Magento\LoginAsCustomer\Model\Config $config
+    ) {
+        $this->config = $config;
+    }
+
+    /**
+     * Retrieve true if login as a customer is enabled
+     * @return bool
+     */
+    public function isEnabled():bool
+    {
+        return $this->config->isEnabled();
+    }
+}

--- a/app/code/Magento/LoginAsCustomer/etc/adminhtml/system.xml
+++ b/app/code/Magento/LoginAsCustomer/etc/adminhtml/system.xml
@@ -23,11 +23,6 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[If set to "Yes", when login as customer Page Cache will be disabled.]]></comment>
                 </field>
-                <field id="keep_guest_cart" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Keep Guest Shopping Cart Items</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment><![CDATA[If set to "Yes", after login, guest shopping cart will be merged into customer shopping cart.]]></comment>
-                </field>
                 <field id="store_view_login" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Store View To Login In</label>
                     <source_model>Magento\LoginAsCustomer\Model\Config\Source\StoreViewLogin</source_model>

--- a/app/code/Magento/LoginAsCustomer/etc/frontend/di.xml
+++ b/app/code/Magento/LoginAsCustomer/etc/frontend/di.xml
@@ -9,4 +9,12 @@
     <type name="Magento\PageCache\Model\Config">
         <plugin name="las-cache-is-enabled" type="Magento\LoginAsCustomer\Model\PageCache\ConfigPlugin"/>
     </type>
+
+    <type name="Magento\Customer\CustomerData\SectionPoolInterface">
+        <arguments>
+            <argument name="sectionSourceMap" xsi:type="array">
+                <item name="logged_as_customer" xsi:type="string">Magento\LoginAsCustomer\CustomerData\LoginAsCustomer</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/LoginAsCustomer/view/frontend/layout/default.xml
+++ b/app/code/Magento/LoginAsCustomer/view/frontend/layout/default.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="after.body.start">
+            <block name="login_as_customer_notices" template="Magento_LoginAsCustomer::html/notices.phtml">
+                <arguments>
+                    <argument name="config" xsi:type="object">Magento\LoginAsCustomer\ViewModel\Configuration</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Magento/LoginAsCustomer/view/frontend/templates/html/notices.phtml
+++ b/app/code/Magento/LoginAsCustomer/view/frontend/templates/html/notices.phtml
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var \Magento\Framework\View\Element\Template $block */
+?>
+<?php if ($block->getConfig()->isEnabled()) : ?>
+    <div  data-bind="scope: 'loginAsCustomer'" >
+        <div class="message global demo" data-bind="visible: isVisible" style="display: none">
+            <div class="content">
+                <p data-bind="text: new String('Attention! You are logged in as the customer.')"></p>
+            </div>
+        </div>
+    </div>
+    <script type="text/x-magento-init">
+    {
+        "*": {
+            "Magento_Ui/js/core/app": {
+                "components": {
+                    "loginAsCustomer": {
+                        "component": "Magento_LoginAsCustomer/js/view/loginAsCustomer"
+                    }
+                }
+            }
+        }
+    }
+    </script>
+<?php endif; ?>

--- a/app/code/Magento/LoginAsCustomer/view/frontend/web/js/view/loginAsCustomer.js
+++ b/app/code/Magento/LoginAsCustomer/view/frontend/web/js/view/loginAsCustomer.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'uiComponent',
+    'Magento_Customer/js/customer-data'
+], function (Component, customerData) {
+    'use strict';
+
+    return Component.extend({
+
+        defaults: {
+            isVisible: false
+        },
+
+        /** @inheritdoc */
+        initialize: function () {
+            this._super();
+
+            this.customer = customerData.get('customer');
+            this.loginAsCustomer = customerData.get('logged_as_customer');
+            this.isVisible(this.loginAsCustomer().admin_user_id);
+        },
+
+        /** @inheritdoc */
+        initObservable: function () {
+            this._super()
+                .observe('isVisible');
+
+            return this;
+        }
+    });
+});


### PR DESCRIPTION
Remove option to merge guest cart

### Description (*)
Removed option "Keep Guest Shopping Cart Items" that allowed merging guest cart to customer cart once login as a customer.

### Fixed Issues (if relevant)
1. magento/magento2#34: Remove option to merge guest cart

### Manual testing scenarios (*)

1. Open admin panel and show that 'Keep Guest Shopping Cart Items' setting is removed
2. Open tab with guest cart and add products to guest cart
3. From admin panel, view contents of a customer cart
4. From admin panel, Login as same Customer
5. Verify that contents of the customer cart have not changed


### Contribution checklist (*)
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
