### PR TITLE
34 remove option to merge guest cart v2

### DIFF
--- a/app/code/Magento/LoginAsCustomer/Model/Login.php
+++ b/app/code/Magento/LoginAsCustomer/Model/Login.php
@@ -17,8 +17,6 @@ class Login extends \Magento\Framework\Model\AbstractModel
      */
     const TIME_FRAME = 60;
 
-    const XML_PATH_KEEP_GUEST_CART = 'mfloginascustomer/general/keep_guest_cart';
-
     /**
      * Prefix of model events names
      *
@@ -189,19 +187,10 @@ class Login extends \Magento\Framework\Model\AbstractModel
             /* Logout if logged in */
             $this->_customerSession->logout();
         } else {
-
             $quote = $this->cart->getQuote();
-
-            $keepItems = $this->scopeConfig->getValue(
-                self::XML_PATH_KEEP_GUEST_CART,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-            );
-
-            if (!$keepItems) {
-                /* Remove items from guest cart */
-                foreach ($quote->getAllVisibleItems() as $item) {
-                    $this->cart->removeItem($item->getId());
-                }
+            /* Remove items from guest cart */
+            foreach ($quote->getAllVisibleItems() as $item) {
+                $this->cart->removeItem($item->getId());
             }
             $this->cart->save();
         }

--- a/app/code/Magento/LoginAsCustomer/etc/adminhtml/system.xml
+++ b/app/code/Magento/LoginAsCustomer/etc/adminhtml/system.xml
@@ -7,28 +7,23 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="mfloginascustomer" translate="label" type="text" sortOrder="1" showInDefault="1" >
+        <section id="mfloginascustomer" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
             <class>separator-top</class>
             <label>Login As Customer</label>
             <tab>customer</tab>
             <resource>Magento_LoginAsCustomer::config_section</resource>
-            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" canRestore="1">
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Login As Customer Information</label>
-                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" canRestore="1">
+                <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Extension</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="disable_page_cache" translate="label" type="select" sortOrder="20" showInDefault="1" canRestore="1">
+                <field id="disable_page_cache" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Disable Page Cache For Admin User</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[If set to "Yes", when login as customer Page Cache will be disabled.]]></comment>
                 </field>
-                <field id="keep_guest_cart" translate="label" type="select" sortOrder="30" showInDefault="1" canRestore="1">
-                    <label>Keep Guest Shopping Cart Items</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment><![CDATA[If set to "Yes", after login, guest shopping cart will be merged into customer shopping cart.]]></comment>
-                </field>
-                <field id="store_view_login" translate="label" type="select" sortOrder="40" showInDefault="1" canRestore="1">
+                <field id="store_view_login" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Store View To Login In</label>
                     <source_model>Magento\LoginAsCustomer\Model\Config\Source\StoreViewLogin</source_model>
                     <comment><![CDATA[


### PR DESCRIPTION
Remove option to merge guest cart

### Description (*)
Removed option "Keep Guest Shopping Cart Items" that allowed merging guest cart to customer cart once login as a customer.

### Fixed Issues (if relevant)
1. magento/magento2-login-as-customer#34: Remove option to merge guest cart

### Manual testing scenarios (*)

1. Open admin panel and show that 'Keep Guest Shopping Cart Items' setting is removed
2. Open tab with guest cart and add products to guest cart
3. From admin panel, view contents of a customer cart
4. From admin panel, Login as same Customer
5. Verify that contents of the customer cart have not changed


### Contribution checklist (*)
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
