### PR TITLE
magento2-login-as-customer/issues/102

### DIFF
--- a/app/code/Magento/LoginAsCustomerUi/Controller/Adminhtml/Login/Login.php
+++ b/app/code/Magento/LoginAsCustomerUi/Controller/Adminhtml/Login/Login.php
@@ -34,7 +34,7 @@ use Magento\Store\Model\StoreManagerInterface;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Login extends Action implements HttpGetActionInterface, HttpPostActionInterface
+class Login extends Action implements HttpGetActionInterface
 {
     /**
      * Authorization level of a basic admin session
@@ -140,7 +140,7 @@ class Login extends Action implements HttpGetActionInterface, HttpPostActionInte
         }
 
         try {
-            $this->customerRepository->getById($customerId);
+            $customer = $this->customerRepository->getById($customerId);
         } catch (NoSuchEntityException $e) {
             $this->messageManager->addErrorMessage(__('Customer with this ID are no longer exist.'));
             return $resultRedirect->setPath('customer/index/index');
@@ -167,6 +167,10 @@ class Login extends Action implements HttpGetActionInterface, HttpPostActionInte
         $this->deleteExpiredAuthenticationData->execute($userId);
         $secret = $this->saveAuthenticationData->execute($authenticationData);
 
+        if (empty($storeId)) {
+            $storeId = (int)$customer->getStoreId();
+        }
+
         $redirectUrl = $this->getLoginProceedRedirectUrl($secret, $storeId);
         $resultRedirect->setUrl($redirectUrl);
         return $resultRedirect;
@@ -182,7 +186,7 @@ class Login extends Action implements HttpGetActionInterface, HttpPostActionInte
      */
     private function getLoginProceedRedirectUrl(string $secret, ?int $storeId): string
     {
-        if (null === $storeId) {
+        if (empty($storeId)) {
             $store = $this->storeManager->getDefaultStoreView();
         } else {
             $store = $this->storeManager->getStore($storeId);


### PR DESCRIPTION
Fixed: Admin user is logged into the default website if customer registered on second website

### Description (*)
See https://github.com/magento/magento2-login-as-customer/issues/102


### Fixed Issues (if relevant)
https://github.com/magento/magento2-login-as-customer/issues/102 Admin user is logged into the default website if customer registered on second website
https://github.com/magento/magento2-login-as-customer/issues/58 If multiple stores exist under a specific website, user is logged into the default website for that store
https://github.com/magento/magento2-login-as-customer/issues/134 Login as Customer not working if store view code is added to url

### Manual testing scenarios (*)
Can be found here https://github.com/magento/magento2-login-as-customer/issues/102


### Contribution checklist (*)
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
