### PR TITLE
magento/magento2-login-as-customer#94: "Login as Customer" button must be next to the “Back button” on the left.

### DIFF
--- a/app/code/Magento/LoginAsCustomerAdminUi/Ui/Customer/Component/Control/LoginAsCustomerButton.php
+++ b/app/code/Magento/LoginAsCustomerAdminUi/Ui/Customer/Component/Control/LoginAsCustomerButton.php
@@ -69,7 +69,7 @@ class LoginAsCustomerButton extends GenericButton implements ButtonProviderInter
                 'on_click' => 'window.lacConfirmationPopup("'
                     . $this->escaper->escapeHtml($this->escaper->escapeJs($this->getLoginUrl()))
                     . '")',
-                'sort_order' => 70,
+                'sort_order' => 15,
             ];
         }
 

--- a/app/code/Magento/LoginAsCustomerAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/app/code/Magento/LoginAsCustomerAdminUi/view/adminhtml/web/css/source/_module.less
@@ -39,4 +39,14 @@
             }
         }
     }
+
+    .page-actions {
+        .page-actions-buttons {
+            .login-button {
+                -ms-flex-order: -1;
+                -webkit-order: -1;
+                order: -1;
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-login-as-customer#94: "Login as Customer" button must be next to the “Back button” on the left.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/magento2-login-as-customer#94: "Login as Customer" button must be next to the “Back button” on the left.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
