### PR TITLE
magento/magento2-login-as-customer#172: Persistent banner is not shown when admin is logged in as customer.

### DIFF
--- a/app/code/Magento/LoginAsCustomerFrontendUi/etc/frontend/di.xml
+++ b/app/code/Magento/LoginAsCustomerFrontendUi/etc/frontend/di.xml
@@ -6,6 +6,13 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Customer\CustomerData\SectionPoolInterface">
+        <arguments>
+            <argument name="sectionSourceMap" xsi:type="array">
+                <item name="loggedAsCustomer" xsi:type="string">Magento\LoginAsCustomerFrontendUi\CustomerData\LoginAsCustomerUi</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Framework\App\ActionInterface">
         <plugin name="invalidate_expired_session_plugin"
                 type="Magento\LoginAsCustomerFrontendUi\Plugin\InvalidateExpiredSessionPlugin"/>

--- a/app/code/Magento/LoginAsCustomerFrontendUi/view/frontend/web/js/view/loginAsCustomer.js
+++ b/app/code/Magento/LoginAsCustomerFrontendUi/view/frontend/web/js/view/loginAsCustomer.js
@@ -5,10 +5,11 @@
 
 define([
     'jquery',
+    'underscore',
     'uiComponent',
     'Magento_Customer/js/customer-data',
     'mage/translate'
-], function ($, Component, customer) {
+], function ($, _, Component, customer) {
     'use strict';
 
     return Component.extend({
@@ -63,8 +64,8 @@ define([
 
             if (this.fullname !== undefined && this.websiteName !== undefined) {
                 this.notificationText($.mage.__('You are connected as <strong>%1</strong> on %2')
-                    .replace('%1', this.fullname)
-                    .replace('%2', this.websiteName));
+                    .replace('%1', _.escape(this.fullname))
+                    .replace('%2', _.escape(this.websiteName)));
             }
         }
     });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-login-as-customer#172: Persistent banner is not shown when admin is logged in as customer.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/magento2-login-as-customer#172: Persistent banner is not shown when admin is logged in as customer.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
