### PR TITLE
magento/magento2-login-as-customer#171: Force customer unlogin during admin loglout without additional MySQL queries.

### DIFF
--- a/app/code/Magento/LoginAsCustomer/Plugin/AdminLogoutPlugin.php
+++ b/app/code/Magento/LoginAsCustomer/Plugin/AdminLogoutPlugin.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\LoginAsCustomer\Plugin;
 
 use Magento\Backend\Model\Auth;
+use Magento\Backend\Model\Auth\Session as AuthSession;
 use Magento\LoginAsCustomerApi\Api\ConfigInterface;
 use Magento\LoginAsCustomerApi\Api\DeleteAuthenticationDataForUserInterface;
 
@@ -16,6 +17,11 @@ use Magento\LoginAsCustomerApi\Api\DeleteAuthenticationDataForUserInterface;
  */
 class AdminLogoutPlugin
 {
+    /**
+     * @var AuthSession
+     */
+    private $authSession;
+
     /**
      * @var ConfigInterface
      */
@@ -27,13 +33,16 @@ class AdminLogoutPlugin
     private $deleteAuthenticationDataForUser;
 
     /**
+     * @param AuthSession $authSession
      * @param ConfigInterface $config
      * @param DeleteAuthenticationDataForUserInterface $deleteAuthenticationDataForUser
      */
     public function __construct(
+        AuthSession $authSession,
         ConfigInterface $config,
         DeleteAuthenticationDataForUserInterface $deleteAuthenticationDataForUser
     ) {
+        $this->authSession = $authSession;
         $this->config = $config;
         $this->deleteAuthenticationDataForUser = $deleteAuthenticationDataForUser;
     }
@@ -46,7 +55,8 @@ class AdminLogoutPlugin
     public function beforeLogout(Auth $subject): void
     {
         $user = $subject->getUser();
-        if ($this->config->isEnabled() && $user && $user->getIsLoggedAsCustomer()) {
+        $isLoggedAsCustomer = $this->authSession->getIsLoggedAsCustomer();
+        if ($this->config->isEnabled() && $user && $isLoggedAsCustomer) {
             $userId = (int)$user->getId();
             $this->deleteAuthenticationDataForUser->execute($userId);
         }

--- a/app/code/Magento/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/Login.php
+++ b/app/code/Magento/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/Login.php
@@ -167,6 +167,7 @@ class Login extends Action implements HttpGetActionInterface
 
         $this->deleteAuthenticationDataForUser->execute($userId);
         $secret = $this->saveAuthenticationData->execute($authenticationData);
+        $this->authSession->setIsLoggedAsCustomer(true);
 
         $redirectUrl = $this->getLoginProceedRedirectUrl($secret, $storeId);
         $resultRedirect->setUrl($redirectUrl);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-login-as-customer#171: Force customer unlogin during admin loglout without additional MySQL queries.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/magento2-login-as-customer#171: Force customer unlogin during admin loglout without additional MySQL queries.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
