### PR TITLE
magento/magento2-login-as-customer#187: Move frontend-specific code (such as session-related) to LoginAsCustomerFrontendUi module.

### DIFF
--- a/app/code/Magento/LoginAsCustomer/etc/di.xml
+++ b/app/code/Magento/LoginAsCustomer/etc/di.xml
@@ -9,7 +9,6 @@
     <preference for="Magento\LoginAsCustomerApi\Api\Data\AuthenticationDataInterface" type="Magento\LoginAsCustomer\Model\AuthenticationData"/>
     <preference for="Magento\LoginAsCustomerApi\Api\SaveAuthenticationDataInterface" type="Magento\LoginAsCustomer\Model\ResourceModel\SaveAuthenticationData"/>
     <preference for="Magento\LoginAsCustomerApi\Api\GetAuthenticationDataBySecretInterface" type="Magento\LoginAsCustomer\Model\ResourceModel\GetAuthenticationDataBySecret"/>
-    <preference for="Magento\LoginAsCustomerApi\Api\AuthenticateCustomerBySecretInterface" type="Magento\LoginAsCustomer\Model\AuthenticateCustomerBySecret"/>
     <preference for="Magento\LoginAsCustomerApi\Api\DeleteAuthenticationDataForUserInterface" type="Magento\LoginAsCustomer\Model\ResourceModel\DeleteAuthenticationDataForUser"/>
     <preference for="Magento\LoginAsCustomerApi\Api\ConfigInterface" type="Magento\LoginAsCustomer\Model\Config"/>
     <preference for="Magento\LoginAsCustomerApi\Api\IsLoginAsCustomerSessionActiveInterface" type="Magento\LoginAsCustomer\Model\ResourceModel\IsLoginAsCustomerSessionActive"/>

--- a/app/code/Magento/LoginAsCustomerFrontendUi/Model/AuthenticateCustomerBySecret.php
+++ b/app/code/Magento/LoginAsCustomerFrontendUi/Model/AuthenticateCustomerBySecret.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\LoginAsCustomer\Model;
+namespace Magento\LoginAsCustomerFrontendUi\Model;
 
 use Magento\Customer\Model\Session;
 use Magento\Framework\Exception\LocalizedException;

--- a/app/code/Magento/LoginAsCustomerFrontendUi/etc/frontend/di.xml
+++ b/app/code/Magento/LoginAsCustomerFrontendUi/etc/frontend/di.xml
@@ -6,6 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\LoginAsCustomerApi\Api\AuthenticateCustomerBySecretInterface" type="Magento\LoginAsCustomerFrontendUi\Model\AuthenticateCustomerBySecret"/>
     <type name="Magento\Customer\CustomerData\SectionPoolInterface">
         <arguments>
             <argument name="sectionSourceMap" xsi:type="array">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-login-as-customer#187: Move frontend-specific code (such as session-related) to LoginAsCustomerFrontendUi module.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Make sure Login as Customer button on Customer account page works correctly.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
